### PR TITLE
fixed crash issue, When User return to the list screen during playback

### DIFF
--- a/Objective-C/AdvancedExample/AdvancedExample/VideoViewController.m
+++ b/Objective-C/AdvancedExample/AdvancedExample/VideoViewController.m
@@ -121,9 +121,25 @@ typedef enum { PlayButton, PauseButton } PlayButtonType;
       [self.adsManager destroy];
       self.adsManager = nil;
     }
+    
+    [self removeObservers];
     self.contentPlayer = nil;
   }
   [super viewWillDisappear:animated];
+}
+  //Remove ContentPlayer Observer
+- (void)removeObservers {
+  
+  if (self.playHeadObserver) {
+    [self.contentPlayer removeTimeObserver:self.playHeadObserver];
+    self.playHeadObserver = nil;
+  }
+  
+  @try {
+    [self.contentPlayer removeObserver:self forKeyPath:@"rate"];
+    [self.contentPlayer removeObserver:self forKeyPath:@"currentItem.duration"];
+  } @catch (NSException *exception) { }
+  
 }
 
 // If pop-up dialog was shown, request ads with provided tag on dialog close.


### PR DESCRIPTION
HI, 
I fixed crash issue, When User return to the list screen during playback at Advance Sample in Object  C
It seem to be  similar issues will appear in other samples Swift Object both , I will confirm and fix.

Could you please review my pull request ?

Thanks 
Best Regards
Derrick.